### PR TITLE
Add rule for sourcemap

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -62,6 +62,7 @@ gulp.task('compass', function() {
       css: outputDir + 'css',
       image: outputDir + 'images',
       style: sassStyle,
+      sourcemap: true,
       require: ['susy', 'breakpoint']
     })
     .on('error', gutil.log))


### PR DESCRIPTION
Gulp wasn't generating the sourcemap for me, but after adding

> sourcemap: true,

to the gulpfile, the sourcemap is being created in "builds/development/css/style.css.map"
